### PR TITLE
Ajout du CMS custom d'Etalab

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,37 @@
+backend:
+  name: github
+  base_url: https://api.staticweb-01.etalab.gouv.fr
+  site_domain: lactu.beta.gouv.fr
+  repo: betagouv/lactu.beta.gouv.fr
+
+media_folder: "images/uploads"
+
+# Editorial workflow: validate changes through pull requests
+publish_mode: editorial_workflow
+
+collections:
+   - name: "posts"     label: "Posts"
+     folder: "_posts"
+     slug: "{{year}}-{{month}}-{{day}}-{{title}}"
+     create: true
+     fields:
+       - {label: "Layout", name: "layout", widget: "hidden", default: "post"}
+       - {label: "Titre", name: "title", widget: "string"}
+       - {label: "Date", name: "date", widget: "string"}
+       - {label: "Auteur", name: "author", widget: "string", required: false}
+       - {label: "Catégories", name: "categories", widget: "string"}
+       - {label: "Tags", name: "tags", widget: "string", required: false}
+       - {label: "Image", name: "image", widget: image, required: false}
+       - {label: "Chapô", name: "excerpt", widget: "markdown", required: false}
+       - {label: "Contenu", name: "body", widget: "markdown"}
+
+   - name: "newsletters"
+     label: "Newsletters"
+     folder: "_newsletters"
+     slug: "{{year}}-{{month}}-{{day}}-{{title}}"
+     create: true
+     fields:
+       - {label: "Date", name: "date", widget: "string"}
+       - {label: "Focus", name: "focus", widget: "string"}
+       - {label: "Lien", name: "target", widget: "string"}
+              

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -10,7 +10,8 @@ media_folder: "images/uploads"
 publish_mode: editorial_workflow
 
 collections:
-   - name: "posts"     label: "Posts"
+   - name: "posts"
+     label: "Posts"
      folder: "_posts"
      slug: "{{year}}-{{month}}-{{day}}-{{title}}"
      create: true
@@ -34,4 +35,3 @@ collections:
        - {label: "Date", name: "date", widget: "string"}
        - {label: "Focus", name: "focus", widget: "string"}
        - {label: "Lien", name: "target", widget: "string"}
-              

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Content Manager</title>
+
+  <link rel="stylesheet" href="https://netlify.staticweb-01.etalab.gouv.fr/dist/cms.css" />
+
+</head>
+<body>
+  <script src="https://netlify.staticweb-01.etalab.gouv.fr/dist/cms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Cette PR a pour but d'activer Netlify CMS via le module custom d'Etalab.

En attente de confirmation de la part d'Etalab que tout est OK dans la configuration.